### PR TITLE
Update api urls to https

### DIFF
--- a/src/search.js
+++ b/src/search.js
@@ -31,7 +31,7 @@ var searchProviders = {
     name: 'SoundCloud'
   , alias: 'sc'
   , search: (term) => {
-      return fetchJSON('http://api.soundcloud.com/tracks.json', {
+      return fetchJSON('https://api.soundcloud.com/tracks.json', {
         'client_id': config.soundcloudClientId
       , 'q': term
       }).then((json) => {

--- a/src/search.js
+++ b/src/search.js
@@ -54,18 +54,18 @@ class Search {
     var changeHandler = _.throttle(this.changeHandler, 300);
     this.el = document.querySelector(selector);
 
-    document.addEventListener("keyup", ev => {
+    document.addEventListener('keyup', ev => {
       if(ev.keyCode === 27) { //esc key
         let searchInput = document.querySelector('#search-url');
         searchInput.innerHTML = '';
         searchInput.blur();
         this.emptyResults();
       } else if(ev.keyCode === 70 ) { //f key
-        this.toggleFocus('')
+        this.toggleFocus('');
       } else if(ev.keyCode === 89 ) { //y key
-        this.toggleFocus('yt')
+        this.toggleFocus('yt');
       } else if(ev.keyCode === 83 ) { //s key
-        this.toggleFocus('sc')
+        this.toggleFocus('sc');
       }
     });
   }
@@ -149,8 +149,8 @@ class Search {
   renderResults(json) {
     this.results.innerHTML = this.resultsTemplate(json);
     bindEvent(this, '.results .item', 'click', this.clickHandler);
-    bindEvents(this, "#search-results .close", {
-      "click": ev => { this.emptyResults(); }
+    bindEvents(this, '#search-results .close', {
+      'click': ev => { this.emptyResults(); }
     });
   }
 

--- a/src/search.js
+++ b/src/search.js
@@ -9,7 +9,7 @@ var searchProviders = {
     name: 'YouTube'
   , alias: 'yt'
   , search: (term) => {
-      return fetchJSON('http://gdata.youtube.com/feeds/api/videos', {
+      return fetchJSON('https://gdata.youtube.com/feeds/api/videos', {
         'type': 'video'
       , 'max-results': 25
       , 'alt': 'json'


### PR DESCRIPTION
Hi, [EFFs "HTTPS Everywhere"](https://www.eff.org/https-everywhere/) blocks the search functionality on the screeninvader. If search.js is using `https` instead of `http` the search functionality is working.
The pull requests also removes mixed quotation-marks and adds missing semicolons, which is a separate commit. Tested and working on a blank Firefox profile, a Firefox with HTTPS-Everywhere enabled, Epiphany (Webkit) and Vivaldi-Preview-2 (Blink). :beers:
