### PR TITLE
Spotify integration and bugfix

### DIFF
--- a/src/search.js
+++ b/src/search.js
@@ -169,12 +169,16 @@ class Search {
     if (term.length > 0) {
       if (term.startsWith('https://open.spotify.com') && term.indexOf('track') !== -1) {
         fetchJSON('https://api.spotify.com/v1/tracks/' + term.split('/track/')[1]).then((json) => {
-          term = 'v ' + json.name;
-          json.artists.forEach(artist => {
-            term += ' ' + artist.name;
-          });
-          this.input.value = term;
-          this.doSearch(term);
+          if (!json.error) {
+            term = 'v ' + json.name;
+            json.artists.forEach(artist => {
+              term += ' ' + artist.name;
+            });
+            this.input.value = term;
+            this.doSearch(term);
+          } else {
+            this.input.value = '';
+          }
         });
       } else if (term.startsWith('http') || term.startsWith("rtmp") || term.startsWith("magnet")) {
         this.submit.disabled = false;

--- a/src/search.js
+++ b/src/search.js
@@ -167,7 +167,16 @@ class Search {
     let term = ev.target.value;
     this.submit.disabled = true;
     if (term.length > 0) {
-      if (term.startsWith('http') || term.startsWith("rtmp") || term.startsWith("magnet")) {
+      if (term.startsWith('https://open.spotify.com') && term.indexOf('track') !== -1) {
+        fetchJSON('https://api.spotify.com/v1/tracks/' + term.split('/track/')[1]).then((json) => {
+          term = 'v ' + json.name;
+          json.artists.forEach(artist => {
+            term += ' ' + artist.name;
+          });
+          this.input.value = term;
+          this.doSearch(term);
+        });
+      } else if (term.startsWith('http') || term.startsWith("rtmp") || term.startsWith("magnet")) {
         this.submit.disabled = false;
       } else {
         this.doSearch(term);

--- a/src/search.js
+++ b/src/search.js
@@ -207,7 +207,7 @@ class Search {
 
   doSearchDebounced(query) {
     let queryWords = query.split(' ')
-      , providerAlias = _.first(queryWords)
+      , providerAlias = _.first(queryWords).toLowerCase()
       , terms = _.rest(queryWords).join(' ')
     ;
     console.log('alias, terms', providerAlias, terms);


### PR DESCRIPTION
- You can now paste/drag'n'drop Spotify track links into the search bar and it will automatically be replaced by `v $title $artist(s)`.
- Previously the search providerAlias (e.g. `v` or `m`) was case sensitive, but that's crap because on some mobile devices the first letter will automatically become capitalized.
