### PR TITLE
Spotify integration "light"

### DIFF
--- a/src/search.js
+++ b/src/search.js
@@ -167,7 +167,16 @@ class Search {
     let term = ev.target.value;
     this.submit.disabled = true;
     if (term.length > 0) {
-      if (term.startsWith('http') || term.startsWith("rtmp") || term.startsWith("magnet")) {
+      if (term.startsWith('https://open.spotify.com') && term.indexOf('track') !== -1) {
+        fetchJSON('https://api.spotify.com/v1/tracks/' + term.split('/track/')[1]).then((json) => {
+          term = 'v ' + json.name;
+          json.artists.forEach(artist => {
+            term += ' ' + artist.name;
+          });
+          this.input.value = term;
+          this.doSearch(term);
+        });
+      } else if (term.startsWith('http') || term.startsWith("rtmp") || term.startsWith("magnet")) {
         this.submit.disabled = false;
       } else {
         this.doSearch(term);

--- a/src/search.js
+++ b/src/search.js
@@ -167,8 +167,8 @@ class Search {
     let term = ev.target.value;
     this.submit.disabled = true;
     if (term.length > 0) {
-      if (term.startsWith('https://open.spotify.com') && term.indexOf('track') !== -1) {
-        fetchJSON('https://api.spotify.com/v1/tracks/' + term.split('/track/')[1]).then((json) => {
+      if (term.startsWith('spotify:track:') || term.startsWith('https://open.spotify.com/track/')) {
+        fetchJSON('https://api.spotify.com/v1/tracks/' + term.split(/([:\/])track\1/)[2]).then((json) => {
           term = 'v ' + json.name;
           json.artists.forEach(artist => {
             term += ' ' + artist.name;


### PR DESCRIPTION
As it was already previously implemented, this PR introduces the function to translate Spotify track links into human-readable track title and artist(s), which are then automatically searched for using the normal video search function. Just copy/paste the Spotify track link into the search bar (e.g. by drag'n'dropping a track from the Spotify app) and the rest works as usual.

- [x] Fetch track data from Spotify API
- [x] Use Spotify track links (e.g. https://open.spotify.com/track/31Cj7FuXMwt14Zn8L9GBg4) as identifier
- [x] Use Spotify track URI (e.g. spotify:track:31Cj7FuXMwt14Zn8L9GBg4) as identifier
- [ ] Drag'n'drop field – I think that should only be reimplemented if it also works with other inputs than Spotify content to avoid confusion

Deployed to the Lounge-ScreenInvader for testing.