### PR TITLE
Make video the default search

### DIFF
--- a/src/search.js
+++ b/src/search.js
@@ -212,6 +212,15 @@ class Search {
       this.renderProviders(matchingProviders);
     }
 
+    if (matchingProviders.length === 0 && queryWords.length > 0) {
+      terms = queryWords.join(' ');
+      console.log('terms', terms);
+      searchProviders
+        .video
+        .search(terms)
+        .then(this.renderResults.bind(this));
+    }
+
     if (matchingProviders.length === 1 && terms.length > 0) {
       console.log('terms', terms);
       _.first(matchingProviders)

--- a/src/search.js
+++ b/src/search.js
@@ -213,12 +213,10 @@ class Search {
     }
 
     if (matchingProviders.length === 0 && queryWords.length > 0) {
+      matchingProviders = [searchProviders.video];
+      this.renderProviders(matchingProviders);
+      providerAlias = 'v';
       terms = queryWords.join(' ');
-      console.log('terms', terms);
-      searchProviders
-        .video
-        .search(terms)
-        .then(this.renderResults.bind(this));
     }
 
     if (matchingProviders.length === 1 && terms.length > 0) {

--- a/src/search.js
+++ b/src/search.js
@@ -198,7 +198,7 @@ class Search {
 
   doSearchDebounced(query) {
     let queryWords = query.split(' ')
-      , providerAlias = _.first(queryWords)
+      , providerAlias = _.first(queryWords).toLowerCase()
       , terms = _.rest(queryWords).join(' ')
     ;
     console.log('alias, terms', providerAlias, terms);


### PR DESCRIPTION
This PR makes outta_space use the video search as the default search provider. If no search provider name or alias (e.g. 'v') is used as a prefix, a video search will be triggered for the whole search term.

Deployed to the Lounge-ScreenInvader for testing.