### PR TITLE
Redesign for playlist item drag'n'dropping

### DIFF
--- a/src/playlist.js
+++ b/src/playlist.js
@@ -17,8 +17,10 @@ class Playlist {
               class="<%= isActive(current, index) %>
                      <%= oddEven(current) %>">
             <div>
-              <span class="grippy">☰</span>
-              <a class="item" href="#<%= current %>"><%= item.title %></a>
+              <a class="item" href="#<%= current %>">
+                <span class="grippy">☰</span>
+                <%= item.title %>
+              </a>
               <a class="remove">X</a>
               <a class="expand">...</a>
             </div>

--- a/src/playlist.js
+++ b/src/playlist.js
@@ -17,8 +17,8 @@ class Playlist {
               class="<%= isActive(current, index) %>
                      <%= oddEven(current) %>">
             <div>
+              <span class="grippy">☰</span>
               <a class="item" href="#<%= current %>">
-                <span class="grippy">☰</span>
                 <%= item.title %>
               </a>
               <a class="expand">...</a>

--- a/src/playlist.js
+++ b/src/playlist.js
@@ -17,6 +17,7 @@ class Playlist {
               class="<%= isActive(current, index) %>
                      <%= oddEven(current) %>">
             <div>
+              <span class="grippy">☰</span>
               <a class="item" href="#<%= current %>"><%= item.title %></a>
               <a class="remove">X</a>
               <a class="expand">...</a>
@@ -46,7 +47,7 @@ class Playlist {
     bindEvent(this, '#export', 'click', this.exportHandler);
     var sort = Sortable.create(document.querySelector("#playlist ul"), {
       animation: 0, // ms, animation speed moving items when sorting, `0` — without animation
-      handle: "ul", // Restricts sort start click/touch to the specified element
+      handle: ".grippy", // Restricts sort start click/touch to the specified element
       draggable: "li", // Specifies which items inside the element should be sortable
       onUpdate: function (evt){
         api.playlist.shift(evt.oldIndex, evt.newIndex);

--- a/src/playlist.js
+++ b/src/playlist.js
@@ -21,8 +21,8 @@ class Playlist {
                 <span class="grippy">☰</span>
                 <%= item.title %>
               </a>
-              <a class="remove">X</a>
               <a class="expand">...</a>
+              <a class="remove">X</a>
             </div>
             <div class="expanded">
               <a target="_blank" href="<%= item.source %>">Website</a>

--- a/theme/style.less
+++ b/theme/style.less
@@ -86,6 +86,14 @@ header {
 	 	transform: scaleY(-1);
 	 }
 
+  ul span.grippy {
+    cursor: move;
+    float: left;
+    padding: 0 0 0 0.5em;
+  }
+  ul .active span.grippy {
+    color: @background;
+  }
   ul .active .item::before {
     content: '▶ ';
   }

--- a/theme/style.less
+++ b/theme/style.less
@@ -82,9 +82,10 @@ header {
       width: 0%;
     }
   }
-	 ul {
-	 	transform: scaleY(-1);
-	 }
+
+  ul {
+  	transform: scaleY(-1);
+  }
 
   ul span.grippy {
     cursor: move;
@@ -109,18 +110,19 @@ header {
   ul li {
     div {
       width: 100%;
-      display: inline-block;
+      display: flex;
 
       .item {
-        float: left;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
       }
 
       .expand {
-        float: right;
+        margin-left: auto;
       }
 
       .remove {
-        float: right;
       }
 
     }

--- a/theme/style.less
+++ b/theme/style.less
@@ -90,7 +90,7 @@ header {
   ul span.grippy {
     cursor: move;
     float: left;
-    padding-right: 0.5em;
+    padding: 0.1em 0.5em;
   }
   ul .active span.grippy {
     color: @background;
@@ -430,7 +430,7 @@ input[type=range] {
       }
     }
     ul li a {
-      padding: 0 0.5em;
+      padding: 0.1em 0.5em 0.1em 0em;
     }
   }
 }

--- a/theme/style.less
+++ b/theme/style.less
@@ -89,7 +89,7 @@ header {
   ul span.grippy {
     cursor: move;
     float: left;
-    padding: 0 0 0 0.5em;
+    padding-right: 0.5em;
   }
   ul .active span.grippy {
     color: @background;
@@ -219,14 +219,14 @@ header {
   }
   #volume {
     display: inline-block;
-    font-size: 0; 
+    font-size: 0;
   }
 
   #progress {
     display: flex;
     width: 100%;
   }
-  
+
  #progress-bar {
     margin-top: 5px;
     height: 10px;

--- a/theme/style.less
+++ b/theme/style.less
@@ -104,7 +104,6 @@ header {
     color: @background;
     border-radius: 2px;
     padding: 2px 3px;
-    margin-right: 8px;
   }
 
   ul li {


### PR DESCRIPTION
Makes only a little part of the playlist items grippy, so you can scroll on mobile devices without drag'n'dropping around.

Deployed to the Lounge-ScreenInvader for testing.